### PR TITLE
feat: Multi-calendar adapters + event conflict detection

### DIFF
--- a/src/core/chore_scheduler.py
+++ b/src/core/chore_scheduler.py
@@ -132,7 +132,7 @@ async def find_best_slot(
     return result
 
 
-def _time_str_to_minutes(time_str: str) -> int | None:
+def time_str_to_minutes(time_str: str) -> int | None:
     """Convert an ISO datetime or HH:MM string to minutes from midnight."""
     if not time_str:
         return None
@@ -146,7 +146,7 @@ def _time_str_to_minutes(time_str: str) -> int | None:
         return None
 
 
-def _overlaps_any(
+def overlaps_any(
     start: int, end: int, busy: list[tuple[int, int]]
 ) -> bool:
     """Check if [start, end) overlaps with any busy interval."""
@@ -154,3 +154,8 @@ def _overlaps_any(
         if start < be and end > bs:
             return True
     return False
+
+
+# Back-compat aliases
+_time_str_to_minutes = time_str_to_minutes
+_overlaps_any = overlaps_any

--- a/src/core/conflict_checker.py
+++ b/src/core/conflict_checker.py
@@ -1,0 +1,143 @@
+"""
+LifeOS Assistant — Event Conflict Checker.
+
+Detects time conflicts before creating or rescheduling calendar events,
+and suggests nearby free slots as alternatives.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from src.core.chore_scheduler import overlaps_any, time_str_to_minutes
+
+if TYPE_CHECKING:
+    from src.ports.calendar_port import CalendarPort
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConflictResult:
+    """Result of a conflict check against calendar events."""
+
+    has_conflict: bool
+    conflicting_events: list[dict] = field(default_factory=list)
+    suggested_time: str | None = None
+
+
+def extract_event_duration_minutes(event: dict) -> int:
+    """Compute duration from an event's start_time/end_time; default 60 min."""
+    start = time_str_to_minutes(event.get("start_time", ""))
+    end = time_str_to_minutes(event.get("end_time", ""))
+    if start is not None and end is not None and end > start:
+        return end - start
+    return 60
+
+
+def find_nearest_free_slot(
+    busy_intervals: list[tuple[int, int]],
+    duration_minutes: int,
+    requested_start: int,
+    day_start: int = 420,
+    day_end: int = 1320,
+) -> str | None:
+    """Find the nearest free slot of the given duration.
+
+    Searches forward from requested_start in 15-min steps, then backward
+    to day_start. Returns "HH:MM" or None if no slot fits.
+    """
+    sorted_busy = sorted(busy_intervals)
+
+    def _fits(candidate: int) -> bool:
+        candidate_end = candidate + duration_minutes
+        if candidate < day_start or candidate_end > day_end:
+            return False
+        return not overlaps_any(candidate, candidate_end, sorted_busy)
+
+    # Search forward
+    t = requested_start
+    while t + duration_minutes <= day_end:
+        if _fits(t):
+            if t != requested_start:
+                return f"{t // 60:02d}:{t % 60:02d}"
+            # Skip the requested time itself — we already know it conflicts
+        t += 15
+
+    # Search backward
+    t = requested_start - 15
+    while t >= day_start:
+        if _fits(t):
+            return f"{t // 60:02d}:{t % 60:02d}"
+        t -= 15
+
+    return None
+
+
+async def check_conflict(
+    calendar: CalendarPort,
+    target_date: str,
+    start_time: str,
+    duration_minutes: int,
+    exclude_event_id: str | None = None,
+) -> ConflictResult:
+    """Check whether a proposed event conflicts with existing calendar events.
+
+    Args:
+        calendar: Calendar port for fetching events.
+        target_date: ISO date string (YYYY-MM-DD).
+        start_time: Proposed start time (HH:MM).
+        duration_minutes: Duration of the proposed event.
+        exclude_event_id: Event ID to skip (for reschedule self-exclusion).
+
+    Returns:
+        ConflictResult with conflict info and optional suggested alternative.
+    """
+    try:
+        events = await calendar.find_events(target_date=target_date)
+    except Exception as exc:
+        logger.error("Failed to fetch events for conflict check on %s: %s", target_date, exc)
+        return ConflictResult(has_conflict=False)
+
+    # Filter out the excluded event (self-exclusion for reschedule)
+    if exclude_event_id:
+        events = [ev for ev in events if ev.get("id") != exclude_event_id]
+
+    # Build busy intervals, skipping all-day events (no start_time/end_time)
+    busy_intervals: list[tuple[int, int]] = []
+    for ev in events:
+        st = time_str_to_minutes(ev.get("start_time", ""))
+        et = time_str_to_minutes(ev.get("end_time", ""))
+        if st is not None and et is not None:
+            busy_intervals.append((st, et))
+
+    req_start = time_str_to_minutes(start_time)
+    if req_start is None:
+        logger.warning("Invalid start_time for conflict check: %s", start_time)
+        return ConflictResult(has_conflict=False)
+
+    req_end = req_start + duration_minutes
+
+    if not overlaps_any(req_start, req_end, busy_intervals):
+        return ConflictResult(has_conflict=False)
+
+    # Identify which events conflict
+    conflicting = []
+    for ev in events:
+        st = time_str_to_minutes(ev.get("start_time", ""))
+        et = time_str_to_minutes(ev.get("end_time", ""))
+        if st is not None and et is not None:
+            if req_start < et and req_end > st:
+                conflicting.append(ev)
+
+    suggested = find_nearest_free_slot(
+        busy_intervals, duration_minutes, req_start,
+    )
+
+    return ConflictResult(
+        has_conflict=True,
+        conflicting_events=conflicting,
+        suggested_time=suggested,
+    )

--- a/tests/test_conflict_checker.py
+++ b/tests/test_conflict_checker.py
@@ -1,0 +1,169 @@
+"""Tests for src.core.conflict_checker — conflict detection and free slot finding."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.core.conflict_checker import (
+    ConflictResult,
+    check_conflict,
+    extract_event_duration_minutes,
+    find_nearest_free_slot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests for extract_event_duration_minutes
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEventDurationMinutes:
+    def test_iso_times(self):
+        event = {
+            "start_time": "2026-02-07T14:00:00+03:00",
+            "end_time": "2026-02-07T15:30:00+03:00",
+        }
+        assert extract_event_duration_minutes(event) == 90
+
+    def test_hhmm_times(self):
+        event = {"start_time": "09:00", "end_time": "10:00"}
+        assert extract_event_duration_minutes(event) == 60
+
+    def test_missing_times_defaults_to_60(self):
+        assert extract_event_duration_minutes({}) == 60
+
+    def test_missing_end_time_defaults_to_60(self):
+        event = {"start_time": "09:00"}
+        assert extract_event_duration_minutes(event) == 60
+
+    def test_same_start_end_defaults_to_60(self):
+        event = {"start_time": "09:00", "end_time": "09:00"}
+        assert extract_event_duration_minutes(event) == 60
+
+
+# ---------------------------------------------------------------------------
+# Tests for find_nearest_free_slot
+# ---------------------------------------------------------------------------
+
+
+class TestFindNearestFreeSlot:
+    def test_finds_slot_after_busy(self):
+        # Busy 10:00-11:00 (600-660), request at 10:00, duration 30
+        busy = [(600, 660)]
+        result = find_nearest_free_slot(busy, 30, 600)
+        assert result == "11:00"
+
+    def test_finds_slot_before_busy(self):
+        # Busy 10:00-22:00 (600-1320), request at 10:00, duration 30
+        # Forward search fails (day_end=1320), backward should find 09:30
+        busy = [(600, 1320)]
+        result = find_nearest_free_slot(busy, 30, 600)
+        assert result == "09:30"
+
+    def test_returns_none_when_day_fully_booked(self):
+        # Busy from day_start to day_end
+        busy = [(420, 1320)]
+        result = find_nearest_free_slot(busy, 60, 600)
+        assert result is None
+
+    def test_respects_day_bounds(self):
+        # Busy 07:00-22:00, duration 60 — no room
+        busy = [(420, 1320)]
+        result = find_nearest_free_slot(busy, 60, 600, day_start=420, day_end=1320)
+        assert result is None
+
+    def test_finds_gap_between_events(self):
+        # Busy 10:00-11:00 and 12:00-13:00 — gap at 11:00-12:00
+        busy = [(600, 660), (720, 780)]
+        result = find_nearest_free_slot(busy, 30, 600)
+        assert result == "11:00"
+
+    def test_custom_day_bounds(self):
+        # Busy 08:00-09:00, request 08:00, day_start=07:00
+        busy = [(480, 540)]
+        result = find_nearest_free_slot(busy, 30, 480, day_start=420, day_end=1320)
+        assert result == "09:00"
+
+    def test_empty_busy_returns_next_slot(self):
+        # No busy intervals — function skips the requested_start itself
+        # (it's only called when the requested time has a conflict) and
+        # returns the next 15-min increment
+        busy = []
+        result = find_nearest_free_slot(busy, 30, 600)
+        assert result == "10:15"
+
+
+# ---------------------------------------------------------------------------
+# Tests for check_conflict
+# ---------------------------------------------------------------------------
+
+
+def _mock_calendar(events=None, side_effect=None):
+    cal = MagicMock()
+    if side_effect:
+        cal.find_events = AsyncMock(side_effect=side_effect)
+    else:
+        cal.find_events = AsyncMock(return_value=events or [])
+    return cal
+
+
+class TestCheckConflict:
+    @pytest.mark.asyncio
+    async def test_no_conflict(self):
+        cal = _mock_calendar(events=[
+            {"id": "1", "summary": "Lunch", "start_time": "12:00", "end_time": "13:00"},
+        ])
+        result = await check_conflict(cal, "2026-02-07", "14:00", 60)
+        assert result.has_conflict is False
+        assert result.conflicting_events == []
+
+    @pytest.mark.asyncio
+    async def test_overlap_detected(self):
+        cal = _mock_calendar(events=[
+            {"id": "1", "summary": "Meeting", "start_time": "14:00", "end_time": "15:00"},
+        ])
+        result = await check_conflict(cal, "2026-02-07", "14:30", 60)
+        assert result.has_conflict is True
+        assert len(result.conflicting_events) == 1
+        assert result.conflicting_events[0]["summary"] == "Meeting"
+
+    @pytest.mark.asyncio
+    async def test_exclude_self_for_reschedule(self):
+        cal = _mock_calendar(events=[
+            {"id": "ev1", "summary": "My Event", "start_time": "14:00", "end_time": "15:00"},
+        ])
+        # Without exclusion → conflict
+        result = await check_conflict(cal, "2026-02-07", "14:00", 60)
+        assert result.has_conflict is True
+
+        # With self-exclusion → no conflict
+        result = await check_conflict(cal, "2026-02-07", "14:00", 60, exclude_event_id="ev1")
+        assert result.has_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_suggests_alternative_time(self):
+        cal = _mock_calendar(events=[
+            {"id": "1", "summary": "Busy", "start_time": "14:00", "end_time": "15:00"},
+        ])
+        result = await check_conflict(cal, "2026-02-07", "14:00", 60)
+        assert result.has_conflict is True
+        assert result.suggested_time == "15:00"
+
+    @pytest.mark.asyncio
+    async def test_skips_all_day_events(self):
+        cal = _mock_calendar(events=[
+            {"id": "1", "summary": "Holiday", "start_time": "", "end_time": ""},
+        ])
+        result = await check_conflict(cal, "2026-02-07", "10:00", 60)
+        assert result.has_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_calendar_error_returns_no_conflict(self):
+        cal = _mock_calendar(side_effect=Exception("API down"))
+        result = await check_conflict(cal, "2026-02-07", "10:00", 60)
+        assert result.has_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_start_time_returns_no_conflict(self):
+        cal = _mock_calendar(events=[])
+        result = await check_conflict(cal, "2026-02-07", "invalid", 60)
+        assert result.has_conflict is False


### PR DESCRIPTION
## Summary
- **Multi-calendar support**: Added Outlook/365 (Microsoft Graph) and CalDAV calendar adapters with a factory pattern for provider selection via `CALENDAR_PROVIDER` env var
- **Event conflict detection**: Before creating or rescheduling events, the bot checks for time overlaps and presents resolution options via inline keyboard (suggested free slot, force, custom time, cancel)
- **Public scheduler helpers**: Made `time_str_to_minutes` and `overlaps_any` public in `chore_scheduler.py` for reuse by the conflict checker

## Test plan
- [x] 19 new tests in `test_conflict_checker.py` (conflict detection, free slot finding, event duration extraction)
- [x] 13 new tests in `test_telegram_bot.py` (create/reschedule conflict flows, callback handlers, custom time input)
- [x] All 166 tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)