### PR TITLE
ci: Split test suite into per-module parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, master]
 
 jobs:
-  test:
+  test-modules:
     runs-on: ubuntu-latest
 
     strategy:
@@ -50,3 +50,15 @@ jobs:
 
       - name: Run tests — ${{ matrix.module }}
         run: pytest tests/${{ matrix.module }}.py -v
+
+  # Gate job for branch protection — requires all matrix jobs to pass
+  test:
+    if: always()
+    needs: [test-modules]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [ "${{ needs.test-modules.result }}" != "success" ]; then
+            echo "One or more test modules failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Split the single CI test job into 10 parallel jobs using a matrix strategy (`fail-fast: false`)
- Each test module (`test_parser`, `test_telegram_bot`, `test_db`, etc.) runs as its own named job
- Makes it immediately clear in the GitHub Actions UI which module failed

## Test plan
- [ ] Verify all 10 matrix jobs appear in the Actions tab
- [ ] Confirm each job runs only its own test module
- [ ] Confirm `fail-fast: false` lets all jobs complete even if one fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)