### PR TITLE
feat: Add guest/attendee support for calendar events

### DIFF
--- a/src/adapters/caldav_calendar.py
+++ b/src/adapters/caldav_calendar.py
@@ -15,6 +15,7 @@ from datetime import date, datetime, timedelta
 import caldav
 from icalendar import Calendar as iCalendar
 from icalendar import Event as iEvent
+from icalendar import vCalAddress
 
 from src.config import settings
 from src.core.parser import ParsedEvent
@@ -55,6 +56,7 @@ def _build_vevent(
     end_dt: datetime,
     uid: str | None = None,
     rrule: str | None = None,
+    attendees: list[str] | None = None,
 ) -> str:
     """Build an iCalendar VEVENT string."""
     cal = iCalendar()
@@ -75,6 +77,12 @@ def _build_vevent(
             key, _, value = part.partition("=")
             parts[key] = value
         event.add("rrule", parts)
+
+    if attendees:
+        for email in attendees:
+            attendee = vCalAddress(f"mailto:{email}")
+            attendee.params["ROLE"] = "REQ-PARTICIPANT"
+            event.add("attendee", attendee)
 
     cal.add_component(event)
     return cal.to_ical().decode("utf-8")
@@ -148,6 +156,7 @@ class CalDAVCalendarAdapter:
             start_dt=start_dt,
             end_dt=end_dt,
             uid=uid,
+            attendees=parsed_event.guests or None,
         )
 
         try:
@@ -289,6 +298,46 @@ class CalDAVCalendarAdapter:
         except Exception as exc:
             logger.error("CalDAV error (update_event): %s", exc)
             raise CalendarError(f"Failed to update event: {exc}") from exc
+
+    async def add_guests(self, event_id: str, guests: list[str]) -> dict:
+        try:
+            cal = await asyncio.to_thread(_get_calendar)
+            results = await asyncio.to_thread(
+                cal.search, start=datetime(2000, 1, 1), end=datetime(2099, 12, 31), event=True
+            )
+
+            for ev in results:
+                parsed = _parse_vevent(ev)
+                if parsed["id"] != event_id:
+                    continue
+
+                ical = iCalendar.from_ical(ev.data)
+                for component in ical.walk():
+                    if component.name != "VEVENT":
+                        continue
+
+                    existing_emails = set()
+                    for att in component.get("attendee", []):
+                        email = str(att).replace("mailto:", "")
+                        existing_emails.add(email)
+
+                    for email in guests:
+                        if email not in existing_emails:
+                            attendee = vCalAddress(f"mailto:{email}")
+                            attendee.params["ROLE"] = "REQ-PARTICIPANT"
+                            component.add("attendee", attendee)
+
+                    ev.data = ical.to_ical().decode("utf-8")
+                    await asyncio.to_thread(ev.save)
+                    logger.info("Added guests %s to CalDAV event %s", guests, event_id)
+                    return _parse_vevent(ev)
+
+            raise CalendarError(f"Event with UID {event_id} not found.")
+        except CalendarError:
+            raise
+        except Exception as exc:
+            logger.error("CalDAV error (add_guests): %s", exc)
+            raise CalendarError(f"Failed to add guests: {exc}") from exc
 
     async def add_recurring_event(
         self,

--- a/src/adapters/google_calendar.py
+++ b/src/adapters/google_calendar.py
@@ -24,7 +24,7 @@ def _build_event_body(parsed_event: ParsedEvent) -> dict:
     )
     end_dt = start_dt + timedelta(minutes=parsed_event.duration_minutes)
 
-    return {
+    body = {
         "summary": parsed_event.event,
         "description": parsed_event.description,
         "start": {
@@ -36,6 +36,11 @@ def _build_event_body(parsed_event: ParsedEvent) -> dict:
             "timeZone": settings.TIMEZONE,
         },
     }
+
+    if parsed_event.guests:
+        body["attendees"] = [{"email": g} for g in parsed_event.guests]
+
+    return body
 
 
 class GoogleCalendarAdapter:
@@ -186,6 +191,31 @@ class GoogleCalendarAdapter:
         except Exception as exc:
             logger.error("Failed to update event with ID %s: %s", event_id, exc)
             raise CalendarError(f"Failed to update event: {exc}") from exc
+
+    async def add_guests(self, event_id: str, guests: list[str]) -> dict:
+        try:
+            service = get_calendar_service()
+            event = (
+                service.events()
+                .get(calendarId="primary", eventId=event_id)
+                .execute()
+            )
+            existing = event.get("attendees", [])
+            existing_emails = {a["email"] for a in existing}
+            for g in guests:
+                if g not in existing_emails:
+                    existing.append({"email": g})
+            event["attendees"] = existing
+            updated = (
+                service.events()
+                .update(calendarId="primary", eventId=event_id, body=event)
+                .execute()
+            )
+            logger.info("Added guests %s to event %s", guests, event_id)
+            return updated
+        except Exception as exc:
+            logger.error("Failed to add guests to event %s: %s", event_id, exc)
+            raise CalendarError(f"Failed to add guests: {exc}") from exc
 
     async def add_recurring_event(
         self,

--- a/src/integrations/gcal_service.py
+++ b/src/integrations/gcal_service.py
@@ -28,6 +28,7 @@ __all__ = [
     "delete_event",
     "add_recurring_event",
     "update_event",
+    "add_guests",
 ]
 
 _adapter = GoogleCalendarAdapter()
@@ -79,3 +80,8 @@ async def add_recurring_event(
         frequency_days=frequency_days,
         occurrences=occurrences,
     )
+
+
+async def add_guests(event_id: str, guests: list[str]) -> dict:
+    """Deprecated: use CalendarPort.add_guests instead."""
+    return await _adapter.add_guests(event_id, guests)

--- a/src/ports/calendar_port.py
+++ b/src/ports/calendar_port.py
@@ -43,3 +43,7 @@ class CalendarPort(Protocol):
     async def get_daily_events(
         self, target_date: str | None = None
     ) -> list[dict]: ...
+
+    async def add_guests(
+        self, event_id: str, guests: list[str]
+    ) -> dict: ...

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,7 @@ from src.core.parser import (
     CancelAllExcept,
     RescheduleEvent,
     QueryEvents,
+    AddGuests,
     parse_message,
     match_event,
     batch_match_events,
@@ -298,3 +299,47 @@ class TestBatchExcludeEvents:
         ]
         result = await batch_exclude_events([], events)
         assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests for guest parsing
+# ---------------------------------------------------------------------------
+
+
+class TestGuestParsing:
+    @pytest.mark.asyncio
+    async def test_parse_create_with_guests(self):
+        llm_response = '[{"intent": "create", "event": "Meeting with Dan", "date": "2026-02-14", "time": "14:00", "duration_minutes": 60, "description": "", "guests": ["dan@email.com"]}]'
+        with patch("src.core.parser.complete", AsyncMock(return_value=llm_response)):
+            result = await parse_message("Meeting with Dan tomorrow at 14:00, invite dan@email.com")
+        assert len(result) == 1
+        assert isinstance(result[0], ParsedEvent)
+        assert result[0].guests == ["dan@email.com"]
+
+    @pytest.mark.asyncio
+    async def test_parse_create_without_guests(self):
+        llm_response = '[{"intent": "create", "event": "Dentist", "date": "2026-02-14", "time": "16:00", "duration_minutes": 60, "description": ""}]'
+        with patch("src.core.parser.complete", AsyncMock(return_value=llm_response)):
+            result = await parse_message("Dentist tomorrow at 4pm")
+        assert len(result) == 1
+        assert isinstance(result[0], ParsedEvent)
+        assert result[0].guests == []
+
+    @pytest.mark.asyncio
+    async def test_parse_add_guests_intent(self):
+        llm_response = '[{"intent": "add_guests", "event_summary": "Meeting with Dan", "date": "2026-02-14", "guests": ["shon@email.com"]}]'
+        with patch("src.core.parser.complete", AsyncMock(return_value=llm_response)):
+            result = await parse_message("Add shon@email.com to the meeting with Dan tomorrow")
+        assert len(result) == 1
+        assert isinstance(result[0], AddGuests)
+        assert result[0].event_summary == "Meeting with Dan"
+        assert result[0].guests == ["shon@email.com"]
+
+    @pytest.mark.asyncio
+    async def test_parse_add_guests_multiple(self):
+        llm_response = '[{"intent": "add_guests", "event_summary": "Team standup", "date": "2026-02-14", "guests": ["a@test.com", "b@test.com"]}]'
+        with patch("src.core.parser.complete", AsyncMock(return_value=llm_response)):
+            result = await parse_message("Add a@test.com and b@test.com to standup tomorrow")
+        assert len(result) == 1
+        assert isinstance(result[0], AddGuests)
+        assert len(result[0].guests) == 2


### PR DESCRIPTION
## Summary
- Add `guests` field to `ParsedEvent` model for inviting guests when creating events
- Add new `AddGuests` intent model for adding guests to existing events via natural language
- Implement `add_guests()` method across all 3 calendar adapters (Google, Outlook, CalDAV)
- Handle `AddGuests` in `ActionService` for both single-action and batch flows
- Update LLM system prompt with Function 6 (Add Guests) and guests field in Function 1

## Test plan
- [x] Parser tests: create-with-guests, create-without-guests, add_guests intent, multiple guests
- [x] ActionService tests: add_guests success, no match, no events, calendar error, batch flow
- [x] Google adapter tests: build_event_body with/without guests, add_guests, deduplication, failure
- [x] Outlook adapter tests: add_event with/without guests, add_guests success/failure
- [x] CalDAV adapter tests: build_vevent with/without attendees, add_event with/without guests, add_guests success/not found/failure
- [x] All 245 tests pass (27 new)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)