### PR TITLE
feat: Nightly smart alarm notifications

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -65,6 +65,10 @@ class Settings(BaseModel):
     MORNING_BRIEFING_HOUR: int = 8
     TIMEZONE: str = "Asia/Jerusalem"
 
+    # Nightly Alarm
+    NIGHTLY_ALARM_HOUR: int = 21
+    DEFAULT_PREP_TIME_MINUTES: int = 60
+
     @field_validator("ALLOWED_USER_IDS", mode="before")
     @classmethod
     def parse_user_ids(cls, v: str | list[int]) -> list[int]:
@@ -74,9 +78,9 @@ class Settings(BaseModel):
             return [int(uid.strip()) for uid in v.split(",") if uid.strip()]
         return []
 
-    @field_validator("MORNING_BRIEFING_HOUR", mode="before")
+    @field_validator("MORNING_BRIEFING_HOUR", "NIGHTLY_ALARM_HOUR", "DEFAULT_PREP_TIME_MINUTES", mode="before")
     @classmethod
-    def parse_hour(cls, v: str | int) -> int:
+    def parse_int_setting(cls, v: str | int) -> int:
         return int(v)
 
 
@@ -115,6 +119,8 @@ def _load_settings() -> Settings:
         GOOGLE_MAPS_API_KEY=os.getenv("GOOGLE_MAPS_API_KEY", ""),
         MORNING_BRIEFING_HOUR=os.getenv("MORNING_BRIEFING_HOUR", "8"),
         TIMEZONE=os.getenv("TIMEZONE", "Asia/Jerusalem"),
+        NIGHTLY_ALARM_HOUR=os.getenv("NIGHTLY_ALARM_HOUR", "21"),
+        DEFAULT_PREP_TIME_MINUTES=os.getenv("DEFAULT_PREP_TIME_MINUTES", "60"),
     )
 
 

--- a/src/core/alarm_calculator.py
+++ b/src/core/alarm_calculator.py
@@ -1,0 +1,126 @@
+"""Nightly alarm calculator — pure business logic.
+
+Finds the first timed event of the day, calculates the optimal alarm time
+factoring in preparation time and optional travel time.
+
+No I/O: this module only transforms data.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ALARM = "08:00"
+
+
+@dataclass
+class AlarmRecommendation:
+    """Bundled alarm recommendation data."""
+
+    alarm_time: str            # HH:MM
+    event_summary: str
+    event_start: str           # HH:MM
+    prep_minutes: int
+    travel_minutes: int | None
+    travel_text: str | None    # e.g. "30 mins (25 km)"
+
+
+def _extract_time(raw: str) -> tuple[int, int]:
+    """Extract (hour, minute) from an ISO datetime or HH:MM string.
+
+    Raises ValueError on malformed input.
+    """
+    if "T" in raw:
+        time_part = raw.split("T")[1][:5]
+    else:
+        time_part = raw[:5]
+
+    if ":" not in time_part:
+        raise ValueError(f"No colon in time part: {time_part!r}")
+
+    hour, minute = map(int, time_part.split(":"))
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"Hour/minute out of range: {hour}:{minute}")
+    return hour, minute
+
+
+def find_first_timed_event(events: list[dict]) -> dict | None:
+    """Return the earliest timed (non-all-day) event, or None.
+
+    All-day events have start_time without a "T" separator (just a date).
+    Timed events have ISO format like "2025-01-15T09:00:00+02:00".
+    """
+    timed = [ev for ev in events if "T" in ev.get("start_time", "")]
+    if not timed:
+        return None
+    timed.sort(key=lambda ev: ev["start_time"])
+    return timed[0]
+
+
+def calculate_alarm_time(
+    event_start: str,
+    prep_minutes: int,
+    travel_minutes: int = 0,
+) -> str:
+    """Calculate alarm time as HH:MM given an event start time.
+
+    Args:
+        event_start: ISO datetime string (e.g. "2025-01-15T09:00:00+02:00")
+                     or HH:MM time string.
+        prep_minutes: Minutes needed for morning preparation.
+        travel_minutes: Minutes needed for travel (0 if unknown).
+
+    Returns:
+        Alarm time as "HH:MM" string, or "08:00" on parse failure.
+    """
+    try:
+        hour, minute = _extract_time(event_start)
+    except (ValueError, IndexError) as exc:
+        logger.warning("Failed to parse event time '%s': %s", event_start, exc)
+        return _DEFAULT_ALARM
+
+    event_dt = datetime(2000, 1, 2, hour, minute)  # arbitrary date for time math
+    alarm_dt = event_dt - timedelta(minutes=prep_minutes + travel_minutes)
+    return alarm_dt.strftime("%H:%M")
+
+
+def build_alarm_recommendation(
+    event: dict,
+    prep_minutes: int,
+    travel_minutes: int | None = None,
+    travel_text: str | None = None,
+) -> AlarmRecommendation:
+    """Build a complete alarm recommendation from event data."""
+    actual_travel = travel_minutes or 0
+    alarm_time = calculate_alarm_time(
+        event["start_time"], prep_minutes, actual_travel,
+    )
+
+    start_time = event["start_time"]
+    if "T" in start_time:
+        start_time = start_time.split("T")[1][:5]
+
+    return AlarmRecommendation(
+        alarm_time=alarm_time,
+        event_summary=event.get("summary", "(no title)"),
+        event_start=start_time,
+        prep_minutes=prep_minutes,
+        travel_minutes=travel_minutes,
+        travel_text=travel_text,
+    )
+
+
+def is_late_start(event_start: str, threshold_hour: int = 12) -> bool:
+    """Check if the first event starts after a threshold hour (default noon).
+
+    Used to append a "enjoy a relaxed morning" note.
+    """
+    try:
+        hour, _ = _extract_time(event_start)
+    except (ValueError, IndexError):
+        return False
+    return hour >= threshold_hour

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -1,9 +1,11 @@
 """
-LifeOS Assistant — Morning Briefing Scheduler.
+LifeOS Assistant — Daily Schedulers.
 
-The Morning Briefing pillar: a proactive daily push at 08:00 Asia/Jerusalem.
-The user starts their day with a friendly, LLM-written summary of
-today's calendar events and due chores — without needing to ask.
+Morning Briefing: a proactive daily push at 08:00 Asia/Jerusalem with
+an LLM-written summary of today's calendar events and due chores.
+
+Nightly Alarm: a 21:00 push recommending when to set the alarm for
+tomorrow's first event, factoring in prep time and travel time.
 
 This module is provider-agnostic: it depends on CalendarPort and
 NotificationPort protocols, not on specific implementations.
@@ -18,6 +20,8 @@ from src.config import settings
 from src.core.llm import complete
 
 if TYPE_CHECKING:
+    from src.core.alarm_calculator import AlarmRecommendation
+    from src.data.models import User
     from src.ports.calendar_port import CalendarPort
     from src.ports.notification_port import NotificationPort
 
@@ -155,3 +159,124 @@ async def _build_morning_summary(
         logger.warning("Morning briefing: LLM summarization failed: %s", exc)
         # Fallback: raw text
         return f"בוקר טוב! ☀️\n\n{raw_data}"
+
+
+# ---------------------------------------------------------------------------
+# Nightly alarm recommendation
+# ---------------------------------------------------------------------------
+
+
+async def send_nightly_alarm(
+    notifier: NotificationPort,
+    user_db: object | None = None,
+) -> None:
+    """Send nightly alarm recommendation to all onboarded users.
+
+    Iterates over onboarded users, fetches tomorrow's events,
+    finds the first timed event, and sends an alarm suggestion.
+    """
+    if user_db is None:
+        return
+
+    from src.adapters.calendar_factory import create_calendar_adapter
+
+    users = user_db.list_users()
+    for user in users:
+        if not user.onboarded:
+            continue
+        try:
+            user_cal = create_calendar_adapter(token_json=user.calendar_token_json)
+            message = await _send_alarm_for_user(user, user_cal, notifier)
+            if message:
+                logger.info("Nightly alarm sent to user %d", user.telegram_user_id)
+        except Exception as exc:
+            logger.error(
+                "Failed to send nightly alarm to %d: %s",
+                user.telegram_user_id, exc,
+            )
+
+
+async def _send_alarm_for_user(
+    user: User,
+    calendar: CalendarPort,
+    notifier: NotificationPort,
+) -> str | None:
+    """Fetch tomorrow's events, calculate alarm, send notification.
+
+    Returns the message sent, or None if no notification was needed.
+    """
+    from datetime import date, timedelta
+
+    from src.core.alarm_calculator import (
+        build_alarm_recommendation,
+        find_first_timed_event,
+        is_late_start,
+    )
+
+    tomorrow = date.today() + timedelta(days=1)
+    tomorrow_str = tomorrow.isoformat()
+
+    events = await calendar.get_daily_events(target_date=tomorrow_str)
+    if not events:
+        return None
+
+    first_event = find_first_timed_event(events)
+    if first_event is None:
+        return None
+
+    # Try to get travel time
+    travel_minutes, travel_text = await _get_travel_for_event(user, first_event)
+
+    prep_minutes = settings.DEFAULT_PREP_TIME_MINUTES
+    rec = build_alarm_recommendation(
+        first_event, prep_minutes, travel_minutes, travel_text,
+    )
+    late = is_late_start(first_event["start_time"])
+
+    message = _format_alarm_message(rec, late)
+    await notifier.send_message(user.telegram_user_id, message)
+    return message
+
+
+async def _get_travel_for_event(
+    user: User,
+    event: dict,
+) -> tuple[int | None, str | None]:
+    """Look up travel time from user's home to event location.
+
+    Returns (duration_minutes, display_text) or (None, None) on any failure.
+    """
+    home = getattr(user, "home_address", None)
+    location = event.get("location")
+    api_key = settings.GOOGLE_MAPS_API_KEY
+
+    if not home or not location or not api_key:
+        return None, None
+
+    try:
+        from src.integrations.google_maps import get_travel_time
+
+        result = await get_travel_time(home, location, api_key)
+        if result is None:
+            return None, None
+        return result.duration_minutes, f"{result.duration_text} ({result.distance_text})"
+    except Exception as exc:
+        logger.warning("Travel time lookup failed: %s", exc)
+        return None, None
+
+
+def _format_alarm_message(rec: AlarmRecommendation, late: bool) -> str:
+    """Format a human-readable alarm notification message."""
+    lines = [
+        f"Set your alarm for *{rec.alarm_time}*",
+        f"Tomorrow's first event: *{rec.event_summary}* at {rec.event_start}",
+        f"Prep time: {rec.prep_minutes} min",
+    ]
+
+    if rec.travel_minutes is not None:
+        lines.append(f"Travel: {rec.travel_text}")
+
+    if late:
+        lines.append("\nYour first event is after noon — enjoy a relaxed morning!")
+
+    return "\n".join(lines)

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -20,6 +20,7 @@ class User:
     calendar_token_json: str | None = None
     onboarded: bool = False
     invited_by: int | None = None
+    home_address: str | None = None
     is_admin: bool = False
     created_at: str = ""
 

--- a/tests/test_alarm_calculator.py
+++ b/tests/test_alarm_calculator.py
@@ -1,0 +1,120 @@
+"""Tests for src.core.alarm_calculator — pure alarm logic."""
+
+from src.core.alarm_calculator import (
+    AlarmRecommendation,
+    build_alarm_recommendation,
+    calculate_alarm_time,
+    find_first_timed_event,
+    is_late_start,
+)
+
+
+class TestFindFirstTimedEvent:
+    def test_returns_earliest_timed_event(self):
+        events = [
+            {"summary": "Lunch", "start_time": "2025-01-15T12:00:00+02:00"},
+            {"summary": "Standup", "start_time": "2025-01-15T09:00:00+02:00"},
+            {"summary": "Dinner", "start_time": "2025-01-15T19:00:00+02:00"},
+        ]
+        result = find_first_timed_event(events)
+        assert result["summary"] == "Standup"
+
+    def test_skips_all_day_events(self):
+        events = [
+            {"summary": "Holiday", "start_time": "2025-01-15"},
+            {"summary": "Meeting", "start_time": "2025-01-15T10:00:00+02:00"},
+        ]
+        result = find_first_timed_event(events)
+        assert result["summary"] == "Meeting"
+
+    def test_all_day_only_returns_none(self):
+        events = [
+            {"summary": "Holiday", "start_time": "2025-01-15"},
+            {"summary": "Birthday", "start_time": "2025-01-16"},
+        ]
+        assert find_first_timed_event(events) is None
+
+    def test_empty_list_returns_none(self):
+        assert find_first_timed_event([]) is None
+
+    def test_missing_start_time_skipped(self):
+        events = [
+            {"summary": "No time"},
+            {"summary": "Has time", "start_time": "2025-01-15T08:00:00"},
+        ]
+        result = find_first_timed_event(events)
+        assert result["summary"] == "Has time"
+
+
+class TestCalculateAlarmTime:
+    def test_basic_calculation(self):
+        assert calculate_alarm_time("2025-01-15T09:00:00+02:00", 60) == "08:00"
+
+    def test_with_travel_time(self):
+        assert calculate_alarm_time("2025-01-15T09:00:00+02:00", 60, 30) == "07:30"
+
+    def test_wraps_past_midnight(self):
+        """Very early event + prep wraps to previous day's time."""
+        result = calculate_alarm_time("2025-01-15T01:00:00+02:00", 120)
+        assert result == "23:00"
+
+    def test_hhmm_input(self):
+        assert calculate_alarm_time("08:30", 30) == "08:00"
+
+    def test_zero_prep(self):
+        assert calculate_alarm_time("2025-01-15T10:00:00", 0) == "10:00"
+
+    def test_zero_travel(self):
+        assert calculate_alarm_time("2025-01-15T10:00:00", 60, 0) == "09:00"
+
+
+class TestBuildAlarmRecommendation:
+    def test_basic_recommendation(self):
+        event = {
+            "summary": "Standup",
+            "start_time": "2025-01-15T09:00:00+02:00",
+        }
+        rec = build_alarm_recommendation(event, prep_minutes=60)
+        assert isinstance(rec, AlarmRecommendation)
+        assert rec.alarm_time == "08:00"
+        assert rec.event_summary == "Standup"
+        assert rec.event_start == "09:00"
+        assert rec.prep_minutes == 60
+        assert rec.travel_minutes is None
+        assert rec.travel_text is None
+
+    def test_with_travel(self):
+        event = {
+            "summary": "Client meeting",
+            "start_time": "2025-01-15T10:00:00+02:00",
+        }
+        rec = build_alarm_recommendation(
+            event, prep_minutes=60, travel_minutes=30, travel_text="30 mins (25 km)",
+        )
+        assert rec.alarm_time == "08:30"
+        assert rec.travel_minutes == 30
+        assert rec.travel_text == "30 mins (25 km)"
+
+    def test_no_title_uses_default(self):
+        event = {"start_time": "2025-01-15T09:00:00"}
+        rec = build_alarm_recommendation(event, prep_minutes=30)
+        assert rec.event_summary == "(no title)"
+
+
+class TestIsLateStart:
+    def test_morning_event_not_late(self):
+        assert is_late_start("2025-01-15T08:00:00+02:00") is False
+
+    def test_noon_event_is_late(self):
+        assert is_late_start("2025-01-15T12:00:00+02:00") is True
+
+    def test_afternoon_event_is_late(self):
+        assert is_late_start("2025-01-15T14:30:00+02:00") is True
+
+    def test_custom_threshold(self):
+        assert is_late_start("2025-01-15T10:00:00+02:00", threshold_hour=10) is True
+        assert is_late_start("2025-01-15T09:59:00+02:00", threshold_hour=10) is False
+
+    def test_hhmm_input(self):
+        assert is_late_start("13:00") is True
+        assert is_late_start("11:00") is False

--- a/tests/test_scheduler_alarm.py
+++ b/tests/test_scheduler_alarm.py
@@ -1,0 +1,312 @@
+"""Tests for nightly alarm functions in src.core.scheduler."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.scheduler import (
+    _format_alarm_message,
+    _get_travel_for_event,
+    _send_alarm_for_user,
+    send_nightly_alarm,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    telegram_user_id: int = 12345,
+    onboarded: bool = True,
+    home_address: str | None = None,
+    calendar_token_json: str | None = '{"token": "abc"}',
+):
+    user = MagicMock()
+    user.telegram_user_id = telegram_user_id
+    user.onboarded = onboarded
+    user.home_address = home_address
+    user.calendar_token_json = calendar_token_json
+    return user
+
+
+def _make_timed_event(
+    summary: str = "Standup",
+    start_time: str = "2025-01-15T09:00:00+02:00",
+    location: str | None = None,
+):
+    event = {"summary": summary, "start_time": start_time}
+    if location:
+        event["location"] = location
+    return event
+
+
+# ---------------------------------------------------------------------------
+# send_nightly_alarm
+# ---------------------------------------------------------------------------
+
+
+class TestSendNightlyAlarm:
+    @pytest.mark.asyncio
+    async def test_no_user_db_does_nothing(self):
+        notifier = AsyncMock()
+        await send_nightly_alarm(notifier, user_db=None)
+        notifier.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_onboarded_users(self):
+        notifier = AsyncMock()
+        user_db = MagicMock()
+        user_db.list_users.return_value = [_make_user(onboarded=False)]
+
+        with patch("src.adapters.calendar_factory.create_calendar_adapter") as mock_cal:
+            await send_nightly_alarm(notifier, user_db=user_db)
+
+        mock_cal.assert_not_called()
+        notifier.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_alarm_to_onboarded_user(self):
+        notifier = AsyncMock()
+        user = _make_user()
+        user_db = MagicMock()
+        user_db.list_users.return_value = [user]
+
+        mock_cal = AsyncMock()
+        mock_cal.get_daily_events = AsyncMock(return_value=[
+            _make_timed_event(),
+        ])
+
+        with patch("src.adapters.calendar_factory.create_calendar_adapter", return_value=mock_cal):
+            await send_nightly_alarm(notifier, user_db=user_db)
+
+        notifier.send_message.assert_called_once()
+        call_args = notifier.send_message.call_args
+        assert call_args[0][0] == 12345
+        assert "alarm" in call_args[0][1].lower() or "Standup" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_handles_user_error_gracefully(self):
+        notifier = AsyncMock()
+        user = _make_user()
+        user_db = MagicMock()
+        user_db.list_users.return_value = [user]
+
+        with patch(
+            "src.adapters.calendar_factory.create_calendar_adapter",
+            side_effect=Exception("Calendar error"),
+        ):
+            # Should not raise
+            await send_nightly_alarm(notifier, user_db=user_db)
+
+        notifier.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _send_alarm_for_user
+# ---------------------------------------------------------------------------
+
+
+class TestSendAlarmForUser:
+    @pytest.mark.asyncio
+    async def test_no_events_returns_none(self):
+        user = _make_user()
+        calendar = AsyncMock()
+        calendar.get_daily_events = AsyncMock(return_value=[])
+        notifier = AsyncMock()
+
+        result = await _send_alarm_for_user(user, calendar, notifier)
+
+        assert result is None
+        notifier.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_day_only_returns_none(self):
+        user = _make_user()
+        calendar = AsyncMock()
+        calendar.get_daily_events = AsyncMock(return_value=[
+            {"summary": "Holiday", "start_time": "2025-01-15"},
+        ])
+        notifier = AsyncMock()
+
+        result = await _send_alarm_for_user(user, calendar, notifier)
+
+        assert result is None
+        notifier.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_alarm_for_timed_event(self):
+        user = _make_user()
+        calendar = AsyncMock()
+        calendar.get_daily_events = AsyncMock(return_value=[
+            _make_timed_event(summary="Team sync", start_time="2025-01-15T10:00:00+02:00"),
+        ])
+        notifier = AsyncMock()
+
+        with patch("src.core.scheduler._get_travel_for_event", return_value=(None, None)):
+            result = await _send_alarm_for_user(user, calendar, notifier)
+
+        assert result is not None
+        assert "09:00" in result  # 10:00 - 60 min prep
+        assert "Team sync" in result
+        notifier.send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_includes_travel_time(self):
+        user = _make_user(home_address="Home St")
+        calendar = AsyncMock()
+        calendar.get_daily_events = AsyncMock(return_value=[
+            _make_timed_event(
+                summary="Client meeting",
+                start_time="2025-01-15T10:00:00+02:00",
+                location="Office Blvd",
+            ),
+        ])
+        notifier = AsyncMock()
+
+        with patch(
+            "src.core.scheduler._get_travel_for_event",
+            return_value=(30, "30 mins (25 km)"),
+        ):
+            result = await _send_alarm_for_user(user, calendar, notifier)
+
+        assert "08:30" in result  # 10:00 - 60 prep - 30 travel
+        assert "30 mins (25 km)" in result
+
+    @pytest.mark.asyncio
+    async def test_late_start_message(self):
+        user = _make_user()
+        calendar = AsyncMock()
+        calendar.get_daily_events = AsyncMock(return_value=[
+            _make_timed_event(start_time="2025-01-15T14:00:00+02:00"),
+        ])
+        notifier = AsyncMock()
+
+        with patch("src.core.scheduler._get_travel_for_event", return_value=(None, None)):
+            result = await _send_alarm_for_user(user, calendar, notifier)
+
+        assert "relaxed morning" in result
+
+
+# ---------------------------------------------------------------------------
+# _get_travel_for_event
+# ---------------------------------------------------------------------------
+
+
+class TestGetTravelForEvent:
+    @pytest.mark.asyncio
+    async def test_no_home_address(self):
+        user = _make_user(home_address=None)
+        event = _make_timed_event(location="Office")
+        minutes, text = await _get_travel_for_event(user, event)
+        assert minutes is None
+        assert text is None
+
+    @pytest.mark.asyncio
+    async def test_no_event_location(self):
+        user = _make_user(home_address="Home St")
+        event = _make_timed_event()  # no location
+        minutes, text = await _get_travel_for_event(user, event)
+        assert minutes is None
+        assert text is None
+
+    @pytest.mark.asyncio
+    async def test_no_api_key(self):
+        user = _make_user(home_address="Home St")
+        event = _make_timed_event(location="Office")
+        with patch("src.core.scheduler.settings") as mock_settings:
+            mock_settings.GOOGLE_MAPS_API_KEY = ""
+            mock_settings.DEFAULT_PREP_TIME_MINUTES = 60
+            minutes, text = await _get_travel_for_event(user, event)
+        assert minutes is None
+
+    @pytest.mark.asyncio
+    async def test_successful_travel_lookup(self):
+        user = _make_user(home_address="Home St")
+        event = _make_timed_event(location="Office Blvd")
+
+        mock_result = MagicMock()
+        mock_result.duration_minutes = 25
+        mock_result.duration_text = "25 mins"
+        mock_result.distance_text = "20 km"
+
+        with patch("src.core.scheduler.settings") as mock_settings, \
+             patch("src.integrations.google_maps.get_travel_time", return_value=mock_result):
+            mock_settings.GOOGLE_MAPS_API_KEY = "fake-key"
+            minutes, text = await _get_travel_for_event(user, event)
+
+        assert minutes == 25
+        assert "25 mins" in text
+        assert "20 km" in text
+
+    @pytest.mark.asyncio
+    async def test_api_failure_returns_none(self):
+        user = _make_user(home_address="Home St")
+        event = _make_timed_event(location="Office")
+
+        with patch("src.core.scheduler.settings") as mock_settings, \
+             patch(
+                 "src.integrations.google_maps.get_travel_time",
+                 side_effect=Exception("API down"),
+             ):
+            mock_settings.GOOGLE_MAPS_API_KEY = "fake-key"
+            minutes, text = await _get_travel_for_event(user, event)
+
+        assert minutes is None
+        assert text is None
+
+
+# ---------------------------------------------------------------------------
+# _format_alarm_message
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAlarmMessage:
+    def test_basic_message(self):
+        from src.core.alarm_calculator import AlarmRecommendation
+
+        rec = AlarmRecommendation(
+            alarm_time="08:00",
+            event_summary="Standup",
+            event_start="09:00",
+            prep_minutes=60,
+            travel_minutes=None,
+            travel_text=None,
+        )
+        msg = _format_alarm_message(rec, late=False)
+        assert "08:00" in msg
+        assert "Standup" in msg
+        assert "60 min" in msg
+        assert "Travel" not in msg
+        assert "relaxed" not in msg
+
+    def test_with_travel(self):
+        from src.core.alarm_calculator import AlarmRecommendation
+
+        rec = AlarmRecommendation(
+            alarm_time="07:30",
+            event_summary="Meeting",
+            event_start="09:00",
+            prep_minutes=60,
+            travel_minutes=30,
+            travel_text="30 mins (25 km)",
+        )
+        msg = _format_alarm_message(rec, late=False)
+        assert "Travel: 30 mins (25 km)" in msg
+
+    def test_late_start_note(self):
+        from src.core.alarm_calculator import AlarmRecommendation
+
+        rec = AlarmRecommendation(
+            alarm_time="13:00",
+            event_summary="Lunch meeting",
+            event_start="14:00",
+            prep_minutes=60,
+            travel_minutes=None,
+            travel_text=None,
+        )
+        msg = _format_alarm_message(rec, late=True)
+        assert "relaxed morning" in msg

--- a/tests/test_user_db.py
+++ b/tests/test_user_db.py
@@ -76,6 +76,26 @@ class TestUserDBListUsers:
         assert dana.invited_by == 12345
 
 
+class TestUserDBHomeAddress:
+    def test_home_address_default_none(self, user_db):
+        user_db.add_user(12345, "Amit", is_admin=True)
+        user = user_db.get_user(12345)
+        assert user.home_address is None
+
+    def test_set_home_address(self, user_db):
+        user_db.add_user(12345, "Amit", is_admin=True)
+        user_db.set_home_address(12345, "123 Main St, Tel Aviv")
+        user = user_db.get_user(12345)
+        assert user.home_address == "123 Main St, Tel Aviv"
+
+    def test_update_home_address(self, user_db):
+        user_db.add_user(12345, "Amit", is_admin=True)
+        user_db.set_home_address(12345, "Old Address")
+        user_db.set_home_address(12345, "New Address")
+        user = user_db.get_user(12345)
+        assert user.home_address == "New Address"
+
+
 class TestUserDBBackfill:
     def test_backfill_user_id(self, tmp_path):
         """Backfill assigns orphan chores/contacts to a user."""


### PR DESCRIPTION
## Summary
- Adds a nightly 21:00 push notification that recommends when to set the alarm for tomorrow's first event
- Factors in preparation time (60 min default) and travel time via Google Maps Distance Matrix API
- Adds `/sethome` command for users to set their home address (used for travel calculations)

## Changes
### New files (3)
- `src/core/alarm_calculator.py` — Pure logic: find first timed event, calculate alarm time, edge case handling
- `tests/test_alarm_calculator.py` — 14 unit tests for calculator
- `tests/test_scheduler_alarm.py` — 17 integration tests for scheduler orchestration

### Modified files (8)
- `src/data/models.py` — Add `home_address` to `User` dataclass
- `src/data/db.py` — DB migration + `set_home_address()` method
- `src/integrations/google_maps.py` — `TravelTimeResult` + `get_travel_time()` (Distance Matrix API)
- `src/config.py` — `NIGHTLY_ALARM_HOUR` (21) + `DEFAULT_PREP_TIME_MINUTES` (60)
- `src/core/scheduler.py` — `send_nightly_alarm()` orchestration + travel lookup + message formatting
- `src/bot/telegram_bot.py` — `/sethome` handler + nightly alarm job registration + help text
- `tests/test_google_maps.py` — 8 new tests for travel time
- `tests/test_user_db.py` — 3 new tests for home address

## Edge cases handled
- No events tomorrow → skip notification
- All-day events only → skip notification
- No home address / no event location / no API key → alarm with prep only (no travel)
- Distance Matrix API failure → graceful degradation
- Late first event (after noon) → "enjoy a relaxed morning" note
- Very early event → alarm wraps past midnight correctly
- Malformed time strings → fallback to 08:00 default

## Test plan
- [x] All 477 tests pass (`pytest -v`)
- [x] New alarm calculator tests (14 tests)
- [x] New scheduler alarm tests (17 tests)
- [x] Extended Google Maps tests (8 new)
- [x] Extended UserDB tests (3 new)
- [ ] Manual: Set home address via `/sethome`, verify nightly notification at 21:00

Closes #15